### PR TITLE
Boolean JDBC normalizer fails to normalize a java.lang.Boolean #104

### DIFF
--- a/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/BigIntNormalizer.java
+++ b/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/BigIntNormalizer.java
@@ -13,16 +13,9 @@ public class BigIntNormalizer extends JdbcNormalizer<Long> {
     }
 
     @Override
-    public Long normalize(Object value, DbAttribute targetAttribute) {
-
-        if (value == null) {
-            return null;
-        }
+    protected Long doNormalize(Object value, DbAttribute targetAttribute) {
 
         switch (value.getClass().getName()) {
-            case "java.lang.Long": {
-                return (Long) value;
-            }
             case "java.lang.String": {
                 String s = (String) value;
                 return s.isEmpty()? null : Long.valueOf(s);

--- a/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/BooleanNormalizer.java
+++ b/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/BooleanNormalizer.java
@@ -10,11 +10,7 @@ public class BooleanNormalizer extends JdbcNormalizer<Boolean> {
     }
 
     @Override
-    public Boolean normalize(Object value, DbAttribute targetAttribute) {
-
-        if (value == null) {
-            return null;
-        }
+    protected Boolean doNormalize(Object value, DbAttribute targetAttribute) {
 
         switch (value.getClass().getName()) {
             case "java.lang.Byte":

--- a/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/DecimalNormalizer.java
+++ b/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/DecimalNormalizer.java
@@ -14,18 +14,10 @@ public class DecimalNormalizer extends JdbcNormalizer<BigDecimal> {
     }
 
     @Override
-    public BigDecimal normalize(Object value, DbAttribute targetAttribute) {
-
-        if (value == null) {
-            return null;
-        }
+    protected BigDecimal doNormalize(Object value, DbAttribute targetAttribute) {
 
         BigDecimal normalized;
         switch (value.getClass().getName()) {
-            case "java.math.BigDecimal": {
-                normalized = (BigDecimal) value;
-                break;
-            }
             case "java.lang.String": {
                 String s = (String) value;
                 normalized = s.isEmpty()? null : new BigDecimal(s);
@@ -53,6 +45,11 @@ public class DecimalNormalizer extends JdbcNormalizer<BigDecimal> {
             }
         }
 
+        return normalized;
+    }
+
+    @Override
+    protected BigDecimal postNormalize(BigDecimal normalized, DbAttribute targetAttribute) {
         if (normalized == null) {
             return null;
         } else if (targetAttribute == null) {

--- a/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/IntegerNormalizer.java
+++ b/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/IntegerNormalizer.java
@@ -10,16 +10,9 @@ public class IntegerNormalizer extends JdbcNormalizer<Integer> {
     }
 
     @Override
-    public Integer normalize(Object value, DbAttribute targetAttribute) {
-
-        if (value == null) {
-            return null;
-        }
+    protected Integer doNormalize(Object value, DbAttribute targetAttribute) {
 
         switch (value.getClass().getName()) {
-            case "java.lang.Integer": {
-                return (Integer) value;
-            }
             case "java.lang.Long": {
                 return ((Long) value).intValue(); // truncating the value
             }

--- a/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/JdbcNormalizer.java
+++ b/link-move/src/main/java/com/nhl/link/move/runtime/jdbc/JdbcNormalizer.java
@@ -33,5 +33,31 @@ public abstract class JdbcNormalizer<T> {
 	/**
 	 * @since 1.7
 	 */
-	public abstract T normalize(Object value, DbAttribute targetAttribute);
+	@SuppressWarnings("unchecked")
+	public T normalize(Object value, DbAttribute targetAttribute) {
+
+		T result;
+		if (value == null) {
+			result = null;
+		} else if (type.isAssignableFrom(value.getClass())) {
+			result = (T) value;
+		} else {
+			result = doNormalize(value, targetAttribute);
+		}
+
+		return postNormalize(result, targetAttribute);
+	}
+
+	protected abstract T doNormalize(Object value, DbAttribute targetAttribute);
+
+	/**
+	 * Override this method to do post-processing of the normalized value
+	 * (e.g. additional scaling of a decimal)
+	 *
+	 * @see DecimalNormalizer
+     */
+	protected T postNormalize(T normalized, DbAttribute targetAttribute) {
+		// by default just return the value
+		return normalized;
+	}
 }

--- a/link-move/src/test/java/com/nhl/link/move/runtime/jdbc/NormalizerTest.java
+++ b/link-move/src/test/java/com/nhl/link/move/runtime/jdbc/NormalizerTest.java
@@ -1,0 +1,181 @@
+package com.nhl.link.move.runtime.jdbc;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class NormalizerTest {
+
+    private static BigIntNormalizer longNormalizer;
+    private static BooleanNormalizer booleanNormalizer;
+    private static IntegerNormalizer integerNormalizer;
+    private static DecimalNormalizer decimalNormalizer;
+
+    @BeforeClass
+    public static void setUp() {
+        longNormalizer = new BigIntNormalizer();
+        booleanNormalizer = new BooleanNormalizer();
+        decimalNormalizer = new DecimalNormalizer();
+        integerNormalizer = new IntegerNormalizer();
+    }
+
+    @Test
+    public void testNormalizer_Null_To_Long() {
+        assertNull(longNormalizer.normalize(null, null));
+    }
+
+    @Test
+    public void testNormalizer_EmptyString_To_Long() {
+        assertNull(longNormalizer.normalize("", null));
+    }
+
+    @Test
+    public void testNormalizer_String_To_Long() {
+        assertEquals(Long.valueOf(1), longNormalizer.normalize("1", null));
+    }
+
+    @Test
+    public void testNormalizer_Byte_To_Long() {
+        assertEquals(Long.valueOf(1), longNormalizer.normalize((byte) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Short_To_Long() {
+        assertEquals(Long.valueOf(1), longNormalizer.normalize((short) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Integer_To_Long() {
+        assertEquals(Long.valueOf(1), longNormalizer.normalize(1, null));
+    }
+
+    @Test
+    public void testNormalizer_Long_To_Long() {
+        assertEquals(Long.valueOf(1), longNormalizer.normalize((long) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Null_To_Boolean() {
+        assertNull(booleanNormalizer.normalize(null, null));
+    }
+
+    @Test
+    public void testNormalizer_Byte_To_Boolean() {
+        assertEquals(true, booleanNormalizer.normalize((byte) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Short_To_Boolean() {
+        assertEquals(true, booleanNormalizer.normalize((short) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Integer_To_Boolean() {
+        assertEquals(true, booleanNormalizer.normalize(1, null));
+    }
+
+    @Test
+    public void testNormalizer_Long_To_Boolean() {
+        assertEquals(true, booleanNormalizer.normalize((long) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Boolean_To_Boolean() {
+        assertEquals(true, booleanNormalizer.normalize(true, null));
+    }
+
+    @Test
+    public void testNormalizer_Null_To_Integer() {
+        assertNull(integerNormalizer.normalize(null, null));
+    }
+
+    @Test
+    public void testNormalizer_EmptyString_To_Integer() {
+        assertNull(integerNormalizer.normalize("", null));
+    }
+
+    @Test
+    public void testNormalizer_String_To_Integer() {
+        assertEquals(Integer.valueOf(1), integerNormalizer.normalize("1", null));
+    }
+
+    @Test
+    public void testNormalizer_Byte_To_Integer() {
+        assertEquals(Integer.valueOf(1), integerNormalizer.normalize((byte) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Short_To_Integer() {
+        assertEquals(Integer.valueOf(1), integerNormalizer.normalize((short) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Integer_To_Integer() {
+        assertEquals(Integer.valueOf(1), integerNormalizer.normalize(1, null));
+    }
+
+    @Test
+    public void testNormalizer_Long_To_Integer() {
+        assertEquals(Integer.valueOf(1), integerNormalizer.normalize((long) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Null_To_BigDecimal() {
+        assertNull(decimalNormalizer.normalize(null, null));
+    }
+
+    @Test
+    public void testNormalizer_EmptyString_To_BigDecimal() {
+        assertNull(decimalNormalizer.normalize("", null));
+    }
+
+    @Test
+    public void testNormalizer_String_To_BigDecimal() {
+        assertEquals(BigDecimal.ONE, decimalNormalizer.normalize("1", null));
+    }
+
+    @Test
+    public void testNormalizer_Byte_To_BigDecimal() {
+        assertEquals(BigDecimal.ONE, decimalNormalizer.normalize((byte) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Short_To_BigDecimal() {
+        assertEquals(BigDecimal.ONE, decimalNormalizer.normalize((short) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Integer_To_BigDecimal() {
+        assertEquals(BigDecimal.ONE, decimalNormalizer.normalize(1, null));
+    }
+
+    @Test
+    public void testNormalizer_Long_To_BigDecimal() {
+        assertEquals(BigDecimal.ONE, decimalNormalizer.normalize((long) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Float_To_BigDecimal() {
+        assertEquals(BigDecimal.valueOf(1d), decimalNormalizer.normalize((float) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_Double_To_BigDecimal() {
+        assertEquals(BigDecimal.valueOf(1d), decimalNormalizer.normalize((double) 1, null));
+    }
+
+    @Test
+    public void testNormalizer_BigInteger_To_BigDecimal() {
+        assertEquals(BigDecimal.ONE, decimalNormalizer.normalize(BigInteger.ONE, null));
+    }
+
+    @Test
+    public void testNormalizer_BigDecimal_To_BigDecimal() {
+        assertEquals(BigDecimal.ONE, decimalNormalizer.normalize(BigDecimal.ONE, null));
+    }
+}


### PR DESCRIPTION
@andrus , please add this to 1.8 (two link apps are affected, the workaround is to fiddle with the extractor, i.e. return an integer)